### PR TITLE
Extract more informations from rustdoc json to documents

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ bevy = { version = "0.15.0", default-features = false, features = [
 crossterm = "0.28.1"
 bevy-tokio-tasks = { git = "https://github.com/foxzool/bevy-tokio-tasks", branch = "upgrade" }
 xshell = "0.2"
+rustdoc-json = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,3 @@ bevy = { version = "0.15.0", default-features = false, features = [
 crossterm = "0.28.1"
 bevy-tokio-tasks = { git = "https://github.com/foxzool/bevy-tokio-tasks", branch = "upgrade" }
 xshell = "0.2"
-rustdoc-json = "0.1"

--- a/src/document.rs
+++ b/src/document.rs
@@ -86,7 +86,7 @@ fn item_explorer(
                     }
                 }
             }
-            return item_explorer(used.id.unwrap(), current_crate, crates, visited, depth + 1);
+            item_explorer(used.id.unwrap(), current_crate, crates, visited, depth + 1)
         }
         rustdoc_types::ItemEnum::Union(_union) => todo!(),
         rustdoc_types::ItemEnum::Struct(stru) => {

--- a/src/document.rs
+++ b/src/document.rs
@@ -86,7 +86,7 @@ fn item_explorer(
                     }
                 }
             }
-            item_explorer(used.id.unwrap(), current_crate, crates, visited, depth + 1)
+            return item_explorer(used.id.unwrap(), current_crate, crates, visited, depth + 1);
         }
         rustdoc_types::ItemEnum::Union(_union) => todo!(),
         rustdoc_types::ItemEnum::Struct(stru) => {

--- a/src/document.rs
+++ b/src/document.rs
@@ -108,8 +108,8 @@ fn item_explorer(
         rustdoc_types::ItemEnum::TypeAlias(type_alias) => {
             document_type_alias(item, type_alias);
         }
-        rustdoc_types::ItemEnum::Constant(constant) => {
-            document_constant(item, constant);
+        rustdoc_types::ItemEnum::Constant { type_: _, const_ } => {
+            document_constant(item, const_);
         }
         rustdoc_types::ItemEnum::Static(_) => {}
         rustdoc_types::ItemEnum::ExternType => todo!(),
@@ -232,7 +232,7 @@ pub fn document_function(item: &rustdoc_types::Item, func: &rustdoc_types::Funct
     let doc = FunctionDocument {
         name: item.name.as_ref().unwrap().to_string(),
         docs: item.docs.clone(),
-        signature: format!("{:?}", func.decl),
+        signature: format!("{:?}", func.sig),
     };
     doc.write();
 }
@@ -260,7 +260,11 @@ pub fn document_trait(item: &rustdoc_types::Item, trait_item: &rustdoc_types::Tr
     let doc = TraitDocument {
         name: item.name.as_ref().unwrap().to_string(),
         docs: item.docs.clone(),
-        items: trait_item.items.iter().map(|item| format!("{:?}", item)).collect(),
+        items: trait_item
+            .items
+            .iter()
+            .map(|item| format!("{:?}", item))
+            .collect(),
     };
     doc.write();
 }
@@ -301,7 +305,8 @@ pub fn document_type_alias(item: &rustdoc_types::Item, type_alias: &rustdoc_type
 
 impl TypeAliasDocument {
     pub fn write(&self) {
-        let mut file = std::fs::File::create(format!("docs/type_aliases/{}.md", self.name)).unwrap();
+        let mut file =
+            std::fs::File::create(format!("docs/type_aliases/{}.md", self.name)).unwrap();
 
         write!(file, "{} is a type alias.\n\n", self.name).unwrap();
         if let Some(docs) = &self.docs {

--- a/src/document.rs
+++ b/src/document.rs
@@ -97,12 +97,20 @@ fn item_explorer(
             enum_explorer(enume, current_crate, crates, visited, depth);
         }
         rustdoc_types::ItemEnum::Variant(_) => {}
-        rustdoc_types::ItemEnum::Function(_) => {}
-        rustdoc_types::ItemEnum::Trait(_) => {}
+        rustdoc_types::ItemEnum::Function(func) => {
+            document_function(item, func);
+        }
+        rustdoc_types::ItemEnum::Trait(trait_item) => {
+            document_trait(item, trait_item);
+        }
         rustdoc_types::ItemEnum::TraitAlias(_) => todo!(),
         rustdoc_types::ItemEnum::Impl(_) => {}
-        rustdoc_types::ItemEnum::TypeAlias(_) => {}
-        rustdoc_types::ItemEnum::Constant { .. } => {}
+        rustdoc_types::ItemEnum::TypeAlias(type_alias) => {
+            document_type_alias(item, type_alias);
+        }
+        rustdoc_types::ItemEnum::Constant(constant) => {
+            document_constant(item, constant);
+        }
         rustdoc_types::ItemEnum::Static(_) => {}
         rustdoc_types::ItemEnum::ExternType => todo!(),
         rustdoc_types::ItemEnum::Macro(_) => {}
@@ -210,5 +218,123 @@ impl StructDocument {
                 }
             }
         }
+    }
+}
+
+struct FunctionDocument {
+    name: String,
+    docs: Option<String>,
+    signature: String,
+}
+
+pub fn document_function(item: &rustdoc_types::Item, func: &rustdoc_types::Function) {
+    std::fs::create_dir_all("docs/functions").unwrap();
+    let doc = FunctionDocument {
+        name: item.name.as_ref().unwrap().to_string(),
+        docs: item.docs.clone(),
+        signature: format!("{:?}", func.decl),
+    };
+    doc.write();
+}
+
+impl FunctionDocument {
+    pub fn write(&self) {
+        let mut file = std::fs::File::create(format!("docs/functions/{}.md", self.name)).unwrap();
+
+        write!(file, "{} is a function.\n\n", self.name).unwrap();
+        if let Some(docs) = &self.docs {
+            write!(file, "{}\n\n", docs).unwrap();
+        }
+        write!(file, "Signature: {}\n\n", self.signature).unwrap();
+    }
+}
+
+struct TraitDocument {
+    name: String,
+    docs: Option<String>,
+    items: Vec<String>,
+}
+
+pub fn document_trait(item: &rustdoc_types::Item, trait_item: &rustdoc_types::Trait) {
+    std::fs::create_dir_all("docs/traits").unwrap();
+    let doc = TraitDocument {
+        name: item.name.as_ref().unwrap().to_string(),
+        docs: item.docs.clone(),
+        items: trait_item.items.iter().map(|item| format!("{:?}", item)).collect(),
+    };
+    doc.write();
+}
+
+impl TraitDocument {
+    pub fn write(&self) {
+        let mut file = std::fs::File::create(format!("docs/traits/{}.md", self.name)).unwrap();
+
+        write!(file, "{} is a trait.\n\n", self.name).unwrap();
+        if let Some(docs) = &self.docs {
+            write!(file, "{}\n\n", docs).unwrap();
+        }
+        if !self.items.is_empty() {
+            write!(file, "It has the following items: ").unwrap();
+            for item in &self.items {
+                write!(file, "{}, ", item).unwrap();
+            }
+            write!(file, "\n\n").unwrap();
+        }
+    }
+}
+
+struct TypeAliasDocument {
+    name: String,
+    docs: Option<String>,
+    type_alias: String,
+}
+
+pub fn document_type_alias(item: &rustdoc_types::Item, type_alias: &rustdoc_types::TypeAlias) {
+    std::fs::create_dir_all("docs/type_aliases").unwrap();
+    let doc = TypeAliasDocument {
+        name: item.name.as_ref().unwrap().to_string(),
+        docs: item.docs.clone(),
+        type_alias: format!("{:?}", type_alias.type_),
+    };
+    doc.write();
+}
+
+impl TypeAliasDocument {
+    pub fn write(&self) {
+        let mut file = std::fs::File::create(format!("docs/type_aliases/{}.md", self.name)).unwrap();
+
+        write!(file, "{} is a type alias.\n\n", self.name).unwrap();
+        if let Some(docs) = &self.docs {
+            write!(file, "{}\n\n", docs).unwrap();
+        }
+        write!(file, "Type: {}\n\n", self.type_alias).unwrap();
+    }
+}
+
+struct ConstantDocument {
+    name: String,
+    docs: Option<String>,
+    value: String,
+}
+
+pub fn document_constant(item: &rustdoc_types::Item, constant: &rustdoc_types::Constant) {
+    std::fs::create_dir_all("docs/constants").unwrap();
+    let doc = ConstantDocument {
+        name: item.name.as_ref().unwrap().to_string(),
+        docs: item.docs.clone(),
+        value: format!("{:?}", constant.expr),
+    };
+    doc.write();
+}
+
+impl ConstantDocument {
+    pub fn write(&self) {
+        let mut file = std::fs::File::create(format!("docs/constants/{}.md", self.name)).unwrap();
+
+        write!(file, "{} is a constant.\n\n", self.name).unwrap();
+        if let Some(docs) = &self.docs {
+            write!(file, "{}\n\n", docs).unwrap();
+        }
+        write!(file, "Value: {}\n\n", self.value).unwrap();
     }
 }

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -13,7 +13,7 @@ pub async fn generate_embeddings(
     let mut collection_meta = Map::new();
     collection_meta.insert("hnsw:space".to_string(), distance.into());
     let collection = chroma
-        .get_or_create_collection(collection_name, Some(collection_meta))
+        .get_or_create_collection(&collection_name, Some(collection_meta))
         .await?;
 
     let dir = std::fs::read_dir("./docs/structs")?;

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -30,5 +30,25 @@ pub async fn generate_embeddings(
         };
         collection.upsert(entries, None).await?;
     }
+
+    // Load new documents into the embeddings database
+    let doc_types = vec!["functions", "traits", "type_aliases", "constants"];
+    for doc_type in doc_types {
+        let dir = std::fs::read_dir(format!("./docs/{}", doc_type))?;
+        for entry in dir {
+            let entry = entry.unwrap();
+            let path = entry.path();
+            let file_name = path.file_name().unwrap().to_str().unwrap();
+            let entries = CollectionEntries {
+                ids: vec![file_name],
+                embeddings: Some(vec![
+                    ollama.embeddings(&std::fs::read_to_string(&path)?).await?,
+                ]),
+                ..Default::default()
+            };
+            collection.upsert(entries, None).await?;
+        }
+    }
+
     Ok(())
 }

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -13,7 +13,7 @@ pub async fn generate_embeddings(
     let mut collection_meta = Map::new();
     collection_meta.insert("hnsw:space".to_string(), distance.into());
     let collection = chroma
-        .get_or_create_collection(&collection_name, Some(collection_meta))
+        .get_or_create_collection(collection_name, Some(collection_meta))
         .await?;
 
     let dir = std::fs::read_dir("./docs/structs")?;


### PR DESCRIPTION
Add extraction of more information from rustdoc JSON and load new documents into the embeddings database.

* **Cargo.toml**
  - Add `rustdoc-json` dependency version `0.1`.

* **src/document.rs**
  - Add extraction of function signatures and documentation.
  - Add extraction of trait definitions and documentation.
  - Add extraction of type aliases and documentation.
  - Add extraction of constants and documentation.

* **src/embed.rs**
  - Load new documents (functions, traits, type aliases, constants) into the embeddings database.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mockersf/doc-explorer/pull/1?shareId=44b72e57-4fe2-4215-a129-d7a2e785f9ba).